### PR TITLE
Update GitHub workflows to allow manual triggering and create releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release
 on:
   release:
     types:
-      - prereleased
       - released
   push:
     branches:
@@ -15,13 +14,10 @@ on:
       - "go.mod"
       - "go.sum"
       - ".github/workflows/*.yml"
-  pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - "**/*.go"
-      - "go.mod"
-      - "go.sum"
-      - ".github/workflows/*.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -286,6 +282,7 @@ jobs:
           file: build_artifacts/v2ray-extra.zip
           tag: ${{ github.ref }}
           overwrite: true
+
   buildContainer:
     if: github.event_name == 'release'
     needs: signature

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -1,8 +1,10 @@
 name: Sign
 
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   sign:


### PR DESCRIPTION
Update GitHub workflows to improve release and signing processes.

* **release.yml**
  - Remove `pull_request` trigger to prevent workflow from running on pull requests.
  - Add `workflow_dispatch` trigger to allow manual triggering of the workflow.
  - Update `release` trigger to include only the `released` type.
  - Add `permissions` section with `contents: write` to allow the workflow to create releases.

* **sign.yml**
  - Remove `release` trigger to prevent workflow from running on releases.
  - Add `workflow_dispatch` trigger to allow manual triggering of the workflow.
  - Add `permissions` section with `contents: write` to allow the workflow to create releases.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/changeschung/v2ray-core/pull/1?shareId=4883ccc9-5dfa-4fc6-8a08-9031fe6ec05b).